### PR TITLE
Fix error handling code for Roland Smart Tally (Closes #2)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1215,7 +1215,7 @@ function getRolandSmartTally(address)
 
 		request(`http://${ipAddress}/tally/${address}/status`, function (error, response, body) {
 			if (error) {
-				notify.log("Roland Smart Tally Error: " + error, false);
+				notify("Roland Smart Tally Error: " + error, false);
 			}
 			else {
 				processRolandV60HDTally(address, body);


### PR DESCRIPTION
This fixes the exception when an invalid / inaccessible ip address is entered.